### PR TITLE
Changes to GoHome inspired by ethulhu/dwm in #doc, eve of 2013-01-21.

### DIFF
--- a/src/uk/co/harcourtprogramming/docitten/GoHomeService.java
+++ b/src/uk/co/harcourtprogramming/docitten/GoHomeService.java
@@ -54,18 +54,18 @@ public class GoHomeService extends ExternalService
 					{
 						case 40:
 							getInstance().message(channel,
-							  "Ladies and Gentlemen, your attention please: DoC Labs will be closing in 20 minutes");
+							  "Oi, you lot, listen up: DoC Labs will be closing in T minus 20 minutes");
 							Thread.sleep(60000); // Make sure we can't send this twice
 							break;
 						case 50:
 							getInstance().message(channel,
-							  "Ladies and Gentlemen, your attention please: DoC Labs will be closing in 10 minutes\n" +
-							  "A dry, twitty comment should go here!");
+							  "Oi, you lot, listen up: DoC Labs will be closing in T minus 10 minutes\n" +
+							  "GO HOME AND SLEEP AND STUFF!");
 							Thread.sleep(60000); // Make sure we can't send this twice
 							break;
 						case 55:
 							getInstance().message(channel,
-							  "Ladies and Gentlemen, your attention please: DoC Labs will be closing in 5 minutes\n" +
+							  "Oi, you lot, listen up: DoC Labs will be closing in T minus 5 minutes\n" +
 							  "Please save, commit and push your work, log off, and try not to get locked in!");
 							Thread.sleep(60000); // Make sure we can't send this twice
 							break;


### PR DESCRIPTION
Conversation follows:

> < DoCitten> Ladies and Gentlemen, your attention please: DoC Labs will be closing in 20 minutes
>  * ethulhu is neither lady nor gentleman, does not give DoCitten attention
> < DoCitten> Ladies and Gentlemen, your attention please: DoC Labs will be closing in 10 minutes
> < DoCitten> A dry, twitty comment should go here!
> < DoCitten> Ladies and Gentlemen, your attention please: DoC Labs will be closing in 5 minutes
> < DoCitten> Please save, commit and push your work, log off, and try not to get locked in!
> @dwm Hmm.  _ponders alternative wording_
> @dwm Yeah, s/Ladies and Gentlemen, your attention please/Notice/
> @dwm Or just 'Note:'
> < ethulhu> or just "Your attention please: DoC labs will be closing in T minus 10 minutes"
> @dwm Indeed.
> < ethulhu> or "oi, you lot, GO HOME AND SLEEP AND STUFF!"
> @dwm Yes, that flows more nicely.
> < ethulhu> :)
> @dwm ROFL

(note that the caps section replaces the "twitty comment")
