### PR TITLE
Context be damned!

### DIFF
--- a/src/uk/co/harcourtprogramming/docitten/ContextService.java
+++ b/src/uk/co/harcourtprogramming/docitten/ContextService.java
@@ -4,6 +4,7 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import uk.co.harcourtprogramming.docitten.utility.ArrayBuffer;
 import uk.co.harcourtprogramming.internetrelaycats.FilterService;
 import uk.co.harcourtprogramming.internetrelaycats.Message;
@@ -30,6 +31,11 @@ public class ContextService extends Service implements MessageService, FilterSer
 	 * <p>Occasional interjection when asked for context</p>
 	 */
 	private final static String CBD = "Context be damned!";
+
+	/**
+	 * <p>Random number generator for deciding whether to damn context</p>
+	 */
+	private final Random r = new Random();
 
 	/**
 	 * <p>Storage for the history of attached channels</p>

--- a/src/uk/co/harcourtprogramming/docitten/ContextService.java
+++ b/src/uk/co/harcourtprogramming/docitten/ContextService.java
@@ -38,6 +38,11 @@ public class ContextService extends Service implements MessageService, FilterSer
 	private final Random r = new Random();
 
 	/**
+	 * <p>Percentage chance of damning context when it is requested</p>
+	 */
+	private final Int OBJECTION_PERCENT = 10;
+
+	/**
 	 * <p>Storage for the history of attached channels</p>
 	 */
 	private final Map<String, ArrayBuffer<String>> channelHistories = new HashMap<>(10);

--- a/src/uk/co/harcourtprogramming/docitten/ContextService.java
+++ b/src/uk/co/harcourtprogramming/docitten/ContextService.java
@@ -112,6 +112,12 @@ public class ContextService extends Service implements MessageService, FilterSer
 				{
 					m.reply("No context available for this channel.");
 				}
+
+				// occasionally object (but only after answering the request)
+				if (r.nextInt(100) < OBJECTION_PERCENT)
+				{
+					m.replyToAll(CBD);
+				}
 			}
 		}
 	}

--- a/src/uk/co/harcourtprogramming/docitten/ContextService.java
+++ b/src/uk/co/harcourtprogramming/docitten/ContextService.java
@@ -27,6 +27,11 @@ public class ContextService extends Service implements MessageService, FilterSer
 {
 
 	/**
+	 * <p>Occasional interjection when asked for context</p>
+	 */
+	private final static String CBD = "Context be damned!";
+
+	/**
 	 * <p>Storage for the history of attached channels</p>
 	 */
 	private final Map<String, ArrayBuffer<String>> channelHistories = new HashMap<>(10);


### PR DESCRIPTION
Patch occasionally responds publicly to context requests with "Context be damned!" (but only after sending the PM as usual).

Caveat:  adds dependency on java.util.Random, but as that's a) part of the standard library and b) used by at least two other modules, this shouldn't be a massive problem.