### PR TITLE
Fix "Happy HP!" "HELPING!!!"

### DIFF
--- a/src/uk/co/harcourtprogramming/docitten/HelpingService.java
+++ b/src/uk/co/harcourtprogramming/docitten/HelpingService.java
@@ -20,7 +20,7 @@ public class HelpingService extends Service implements MessageService
 	 * <p>Regex to determine when someone is asking for help</p>
 	 */
 	private final static Pattern HELP_PATTERN =
-	    Pattern.compile("(^|\\s)(ha*l*p|assist(ance|ence)?|aid)([^\\w]|$)", Pattern.CASE_INSENSITIVE);
+	    Pattern.compile("(^|\\s)(ha+l+p|assist(ance|ence)?|aid)([^\\w]|$)", Pattern.CASE_INSENSITIVE);
 	/**
 	 * <p>What to say when help is asked for</p>
 	 */


### PR DESCRIPTION
There were two *s in HELP_PATTERN that are now +es.  This meant that it would, for
example, match "Happy HP!", which it no longer does.