### PR TITLE
* LinkResolver.java: Account for <title> with attributes

### DIFF
--- a/src/uk/co/harcourtprogramming/docitten/LinkResolver.java
+++ b/src/uk/co/harcourtprogramming/docitten/LinkResolver.java
@@ -320,7 +320,7 @@ public class LinkResolver extends Thread
 		String line;
 
 		boolean reading = false;
-		int titleTagLength = "<title>".length();
+		int titleTagLength = "<title".length();
 
 		String title = "[No Title Set]";
 
@@ -332,16 +332,18 @@ public class LinkResolver extends Thread
 				break;
 			}
 
-			if (line.contains("<title>"))
+			if (line.contains("<title"))
 			{
 				reading = true;
-				line = line.substring(line.indexOf("<title>") + titleTagLength);
+				line = line.substring(line.indexOf("<title") + titleTagLength);
+				line = line.substring(line.indexof(">") + 1);
 				title = "";
 			}
-			if (line.contains("<TITLE>"))
+			if (line.contains("<TITLE"))
 			{
 				reading = true;
-				line = line.substring(line.indexOf("<TITLE>") + titleTagLength);
+				line = line.substring(line.indexOf("<TITLE") + titleTagLength);
+				line = line.substring(line.indexof(">") + 1);
 				title = "";
 			}
 

--- a/src/uk/co/harcourtprogramming/docitten/LinkResolver.java
+++ b/src/uk/co/harcourtprogramming/docitten/LinkResolver.java
@@ -336,14 +336,14 @@ public class LinkResolver extends Thread
 			{
 				reading = true;
 				line = line.substring(line.indexOf("<title") + titleTagLength);
-				line = line.substring(line.indexof(">") + 1);
+				line = line.substring(line.indexOf(">") + 1);
 				title = "";
 			}
 			if (line.contains("<TITLE"))
 			{
 				reading = true;
 				line = line.substring(line.indexOf("<TITLE") + titleTagLength);
-				line = line.substring(line.indexof(">") + 1);
+				line = line.substring(line.indexOf(">") + 1);
 				title = "";
 			}
 


### PR DESCRIPTION
This is the hacky version, which will break if any of those attributes happen to contain ">".  There is almost certainly a better one, especially as this is not well-tested.

Closes #27 
