### PR TITLE
Fix GiphySearchTest.java

### DIFF
--- a/test/uk/co/harcourtprogramming/docitten/GiphySearchTest.java
+++ b/test/uk/co/harcourtprogramming/docitten/GiphySearchTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.*;
 public class GiphySearchTest
 {
 	private final String uri = "funny cat";
-	private final String expected = "http://giphy.com/embed/ivelTBasMg67S";
+	private final String expected = "http://giphy.com/embed/64zSh1uTE7xxm";
 
 	private String target = null;
 	private String message = null;


### PR DESCRIPTION
It appears that "funny cat" now resolves to a different URI...

Hopefully #28 will pass CI after this goes in.
